### PR TITLE
Grid workers hotfix

### DIFF
--- a/miprometheus/workers/grid_tester_cpu.py
+++ b/miprometheus/workers/grid_tester_cpu.py
@@ -143,7 +143,7 @@ class GridTesterCPU(GridWorker):
         else:    
             # Take into account the minimum value.
             max_processes = min(len(os.sched_getaffinity(0)), self.max_concurrent_runs)
-        self.logger.info('Spanning concurrent processes on {} CPU(s).'.format(max_processes))
+        self.logger.info('Spanning experiments using {} CPU(s) concurrently.'.format(max_processes))
 
         # Run in as many threads as there are CPUs available to the script.
         with ThreadPool(processes=max_processes) as pool:

--- a/miprometheus/workers/grid_tester_cpu.py
+++ b/miprometheus/workers/grid_tester_cpu.py
@@ -28,6 +28,7 @@ grid_tester_cpu.py:
 __author__ = "Tomasz Kornuta & Vincent Marois"
 
 import os
+import shutil
 import subprocess
 from functools import partial
 from multiprocessing.pool import ThreadPool
@@ -60,12 +61,23 @@ class GridTesterCPU(GridWorker):
         # call base constructor
         super(GridTesterCPU, self).__init__(name=name,use_gpu=use_gpu)
 
-        # get number_of_repetitions
-        self.parser.add_argument('--n',
-                                 dest='num_tests',
+        # Get number_of_repetitions
+        self.parser.add_argument('--r',
+                                 dest='experiment_repetitions',
                                  type=int,
                                  default=1,
-                                 help='Number of test experiments to run for each model.')
+                                 help='Number of experiment repetitions to run for each model.'
+                                 '(DEFAULT=1)')
+
+        # Get number_of_repetitions
+        self.parser.add_argument('--m',
+                                 dest='max_concurrent_runs',
+                                 type=int,
+                                 default=-1,
+                                 help='Value limiting the number of concurently running experiments.'
+                                    'The set limit will be truncated by number of available CPUs/GPUs.'
+                                    '(DEFAULT=-1, meaning that it will be set to the number of CPUs/GPUs)')
+
 
     def setup_grid_experiment(self):
         """
@@ -83,13 +95,20 @@ class GridTesterCPU(GridWorker):
         """
         super(GridTesterCPU, self).setup_grid_experiment()
 
+        # Check the presence of mip-tester script.
+        if shutil.which('mip-tester') is None:
+            self.logger.error("Cannot localize the 'mip-tester' script! (hints: please use setup.py to install it)")
+            exit(-1)
+
         directory_chckpnts = self.flags.outdir
-        num_tests = self.flags.num_tests
+        # Get grid settings.
+        experiment_repetitions = self.flags.experiment_repetitions
+        self.max_concurrent_runs = self.flags.max_concurrent_runs
 
         # get all sub-directories paths in outdir, repeating according to flags.num
         self.experiments_list = []
 
-        for _ in range(num_tests):
+        for _ in range(experiment_repetitions):
             for root, dirs, files in os.walk(directory_chckpnts, topdown=True):
                 for name in dirs:
                     self.experiments_list.append(os.path.join(root, name))
@@ -104,6 +123,35 @@ class GridTesterCPU(GridWorker):
 
         self.logger.info('Number of experiments to run: {}'.format(len(self.experiments_list)))
         self.experiments_done = 0
+
+
+    def run_grid_experiment(self):
+        """
+        Main function of the ``GridTesterCPU``.
+
+        Maps the grid experiments to CPU cores in the limit of the maximum concurrent runs allowed or maximum\
+         available cores.
+
+        """
+        # Ask for confirmation - optional.
+        if self.flags.confirm:
+            input('Press any key to continue')
+
+        # Check max number of child processes. 
+        if self.max_concurrent_runs <= 0: # We need at least one proces!
+            max_processes = len(os.sched_getaffinity(0))
+        else:    
+            # Take into account the minimum value.
+            max_processes = min(len(os.sched_getaffinity(0)), self.max_concurrent_runs)
+        self.logger.info('Spanning concurrent processes on {} CPU(s).'.format(max_processes))
+
+        # Run in as many threads as there are CPUs available to the script.
+        with ThreadPool(processes=max_processes) as pool:
+            func = partial(GridTesterCPU.run_experiment, self, prefix="")
+            pool.map(func, self.experiments_list)
+
+        self.logger.info('Grid test experiments finished.')
+
 
     def run_experiment(self, experiment_path: str, prefix=""):
         """
@@ -131,7 +179,7 @@ class GridTesterCPU(GridWorker):
         else:
 
             # Run the test
-            command_str = "{}python3 workers/tester.py --model {} --li {} --ll {}".format(prefix, path_to_model,
+            command_str = "{}mip-tester --model {} --li {} --ll {}".format(prefix, path_to_model,
                                                                                        self.flags.logging_interval,
                                                                                        self.flags.log_level)
             # Add gpu flag if required.
@@ -149,25 +197,6 @@ class GridTesterCPU(GridWorker):
 
             if result.returncode != 0:
                 self.logger.info("Testing exited with code: {}".format(result.returncode))
-
-    def run_grid_experiment(self):
-        """
-        Main function of the ``GridTesterCPU``.
-
-        Maps the grid experiments to CPU cores in the limit of the maximum concurrent runs allowed or maximum\
-         available cores.
-
-        """
-        # Ask for confirmation - optional.
-        if self.flags.confirm:
-            input('Press any key to continue')
-
-        # Run in as many threads as there are CPUs available to the script
-        with ThreadPool(processes=len(os.sched_getaffinity(0))) as pool:
-            func = partial(GridTesterCPU.run_experiment, self, prefix="")
-            pool.map(func, self.experiments_list)
-
-        self.logger.info('Grid test experiments finished.')
 
 
 def main():

--- a/miprometheus/workers/grid_tester_cpu.py
+++ b/miprometheus/workers/grid_tester_cpu.py
@@ -67,7 +67,7 @@ class GridTesterCPU(GridWorker):
                                  type=int,
                                  default=1,
                                  help='Number of experiment repetitions to run for each model.'
-                                 '(DEFAULT=1)')
+                                 ' (DEFAULT=1)')
 
         # Get number_of_repetitions
         self.parser.add_argument('--m',
@@ -76,7 +76,7 @@ class GridTesterCPU(GridWorker):
                                  default=-1,
                                  help='Value limiting the number of concurently running experiments.'
                                     'The set limit will be truncated by number of available CPUs/GPUs.'
-                                    '(DEFAULT=-1, meaning that it will be set to the number of CPUs/GPUs)')
+                                    ' (DEFAULT=-1, meaning that it will be set to the number of CPUs/GPUs)')
 
 
     def setup_grid_experiment(self):

--- a/miprometheus/workers/grid_tester_gpu.py
+++ b/miprometheus/workers/grid_tester_gpu.py
@@ -61,8 +61,12 @@ class GridTesterGPU(GridTesterCPU):
         :type use_gpu: bool
 
         """
-        # call base constructor
+        # Call the base constructor.
         super(GridTesterGPU, self).__init__(name=name,use_gpu=use_gpu)
+        # Check the presence of the CUDA-compatible devices.
+        if (torch.cuda.device_count() == 0):
+            self.logger.error("Cannot use GPU as there are no CUDA-compatible devices present in the system!")
+            exit(-1)
 
     def run_grid_experiment(self):
         """

--- a/miprometheus/workers/grid_tester_gpu.py
+++ b/miprometheus/workers/grid_tester_gpu.py
@@ -105,7 +105,7 @@ class GridTesterGPU(GridTesterCPU):
         else:    
             # Take into account the minimum value.
             max_processes = min(torch.cuda.device_count(), self.max_concurrent_runs)
-        self.logger.info('Spanning concurrent processes on {} GPU(s).'.format(max_processes))
+        self.logger.info('Spanning experiments using {} GPU(s) concurrently.'.format(max_processes))
 
         # Run in as many threads as there are GPUs available to the script.
         with ThreadPool(processes=max_processes) as pool:

--- a/miprometheus/workers/grid_trainer_cpu.py
+++ b/miprometheus/workers/grid_trainer_cpu.py
@@ -27,6 +27,7 @@ grid_trainer_cpu.py:
 __author__ = "Alexis Asseman, Ryan McAvoy, Tomasz Kornuta, Vincent Marois"
 
 import os
+import shutil
 import yaml
 import subprocess
 from time import sleep
@@ -123,19 +124,27 @@ class GridTrainerCPU(GridWorker):
             print('yaml.YAMLERROR:', e)
             exit(-3)
 
+        # Check the presence of mip-*-trainer scripts.
+        if self.flags.online_trainer:
+            if shutil.which('mip-online-trainer') is None:
+                self.logger.error("Cannot localize the 'mip-online-trainer' script! (hints: please use setup.py to install it)")
+                exit(-4)
+        else:
+            if shutil.which('mip-offline-trainer') is None:
+                self.logger.error("Cannot localize the 'mip-offline-trainer' script! (hints: please use setup.py to install it)")
+                exit(-4)
+
         # Get grid settings.
         try:
             experiment_repetitions = grid_dict['grid_settings']['experiment_repetitions']
-            self.max_concurrent_run = grid_dict['grid_settings']['max_concurrent_runs']
-
+            self.max_concurrent_runs = grid_dict['grid_settings']['max_concurrent_runs']
         except KeyError:
             print("Error: The 'grid_settings' section must define 'experiment_repetitions' and 'max_concurrent_runs'.")
-            exit(-4)
+            exit(-5)
 
         # Check the presence of grid_overwrite section.
         if 'grid_overwrite' not in grid_dict:
             grid_overwrite_filename = None
-
         else:
             # Create temporary file with settings that will be overwritten for all tasks.
             grid_overwrite_file = NamedTemporaryFile(mode='w', delete=False)
@@ -145,7 +154,7 @@ class GridTrainerCPU(GridWorker):
         # Check the presence of the tasks section.
         if 'grid_tasks' not in grid_dict:
             print("Error: Grid configuration is lacking the 'grid_tasks' section.")
-            exit(-5)
+            exit(-6)
 
         # Create temporary file
         param_interface_file = NamedTemporaryFile(mode='w', delete=False)
@@ -180,7 +189,7 @@ class GridTrainerCPU(GridWorker):
 
         # at this point, configs should contains the str of config file(s) corresponding to the grid_tasks.
 
-        # Create list of experiments
+        # Create list of experiments, repeat the ones that are required.
         self.experiments_list = []
         for _ in range(experiment_repetitions):
             self.experiments_list.extend(configs)
@@ -203,6 +212,35 @@ class GridTrainerCPU(GridWorker):
                 sleep(1)
             else:
                 break
+
+
+    def run_grid_experiment(self):
+        """
+        Main function of the ``GridTrainerCPU``.
+
+        Maps the grid experiments to CPU cores in the limit of the maximum concurrent runs allowed or maximum\
+         available cores.
+
+        """
+        # Ask for confirmation - optional.
+        if self.flags.confirm:
+            input('Press any key to continue')
+
+        # Check max number of child processes. 
+        if self.max_concurrent_runs <= 0: # We need at least one proces!
+            max_processes = len(os.sched_getaffinity(0))
+        else:    
+            # Take into account the minimum value.
+            max_processes = min(len(os.sched_getaffinity(0)), self.max_concurrent_runs)
+        self.logger.info('Spanning concurrent processes on {} CPU(s).'.format(max_processes))
+
+        # Run in as many threads as there are CPUs available to the script.
+        with ThreadPool(processes=max_processes) as pool:
+            func = partial(GridTrainerCPU.run_experiment, self, prefix="")
+            pool.map(func, self.experiments_list)
+
+        self.logger.info('Grid training experiments finished.')
+
 
     def run_experiment(self, experiment_configs: str, prefix=""):
         """
@@ -227,9 +265,9 @@ class GridTrainerCPU(GridWorker):
         """
         # set the command to be executed using the indicated Trainer
         if self.flags.online_trainer:
-            command_str = "{}python3 workers/online_trainer.py".format(prefix)
+            command_str = "{}workers/online_trainer.py".format(prefix)
         else:
-            command_str = "{}python3 workers/offline_trainer.py".format(prefix)
+            command_str = "{}workers/offline_trainer.py".format(prefix)
 
         # Add gpu flag if required.
         if self.app_state.use_CUDA:
@@ -254,27 +292,6 @@ class GridTrainerCPU(GridWorker):
 
         if result.returncode != 0:
             self.logger.info("Training exited with code: {}".format(result.returncode))
-
-    def run_grid_experiment(self):
-        """
-        Main function of the ``GridTrainerCPU``.
-
-        Maps the grid experiments to CPU cores in the limit of the maximum concurrent runs allowed or maximum\
-         available cores.
-
-        """
-        # Ask for confirmation - optional.
-        if self.flags.confirm:
-            input('Press any key to continue')
-
-        # Run in as many threads as there are CPUs available to the script
-        max_processes = min(len(os.sched_getaffinity(0)), self.max_concurrent_run)
-
-        with ThreadPool(processes=max_processes) as pool:
-            func = partial(GridTrainerCPU.run_experiment, self, prefix="")
-            pool.map(func, self.experiments_list)
-
-        self.logger.info('Grid training experiments finished.')
 
 
 def main():

--- a/miprometheus/workers/grid_trainer_cpu.py
+++ b/miprometheus/workers/grid_trainer_cpu.py
@@ -265,9 +265,9 @@ class GridTrainerCPU(GridWorker):
         """
         # set the command to be executed using the indicated Trainer
         if self.flags.online_trainer:
-            command_str = "{}workers/online_trainer.py".format(prefix)
+            command_str = "{}mip-online-trainer".format(prefix)
         else:
-            command_str = "{}workers/offline_trainer.py".format(prefix)
+            command_str = "{}mip-offline-trainer".format(prefix)
 
         # Add gpu flag if required.
         if self.app_state.use_CUDA:

--- a/miprometheus/workers/grid_trainer_cpu.py
+++ b/miprometheus/workers/grid_trainer_cpu.py
@@ -232,7 +232,7 @@ class GridTrainerCPU(GridWorker):
         else:    
             # Take into account the minimum value.
             max_processes = min(len(os.sched_getaffinity(0)), self.max_concurrent_runs)
-        self.logger.info('Spanning concurrent processes on {} CPU(s).'.format(max_processes))
+        self.logger.info('Spanning experiments using {} CPU(s) concurrently.'.format(max_processes))
 
         # Run in as many threads as there are CPUs available to the script.
         with ThreadPool(processes=max_processes) as pool:

--- a/miprometheus/workers/grid_trainer_gpu.py
+++ b/miprometheus/workers/grid_trainer_gpu.py
@@ -58,8 +58,12 @@ class GridTrainerGPU(GridTrainerCPU):
         :type use_gpu: bool
 
         """
-        # call base constructor
+        # Call the base constructor.
         super(GridTrainerGPU, self).__init__(name=name,use_gpu=use_gpu)
+        # Check the presence of the CUDA-compatible devices.
+        if (torch.cuda.device_count() == 0):
+            self.logger.error("Cannot use GPU as there are no CUDA-compatible devices present in the system!")
+            exit(-1)
 
     def run_grid_experiment(self):
         """

--- a/miprometheus/workers/grid_trainer_gpu.py
+++ b/miprometheus/workers/grid_trainer_gpu.py
@@ -103,7 +103,7 @@ class GridTrainerGPU(GridTrainerCPU):
         else:    
             # Take into account the minimum value.
             max_processes = min(torch.cuda.device_count(), self.max_concurrent_runs)
-        self.logger.info('Spanning concurrent processes on {} GPU(s).'.format(max_processes))
+        self.logger.info('Spanning experiments using {} GPU(s) concurrently.'.format(max_processes))
 
         # Run in as many threads as there are GPUs available to the script.
         with ThreadPool(processes=max_processes) as pool:

--- a/miprometheus/workers/tester.py
+++ b/miprometheus/workers/tester.py
@@ -126,6 +126,11 @@ class Tester(Worker):
             print('Config file {} does not exist'.format(config_file))
             exit(-3)
 
+        # Check the presence of the CUDA-compatible devices.
+        if self.flags.use_gpu and (torch.cuda.device_count() == 0):
+            self.logger.error("Cannot use GPU as there are no CUDA-compatible devices present in the system!")
+            exit(-4)
+
         # Get the list of configurations which need to be loaded.
         configs_to_load = self.recurrent_config_parse(config_file, [])
 

--- a/miprometheus/workers/trainer.py
+++ b/miprometheus/workers/trainer.py
@@ -518,4 +518,4 @@ class Trainer(Worker):
 
 if __name__ == '__main__':
     print("The trainer.py file contains only an abstract base class. Please try to use the \
-online_trainer (mip-onlinetrainer) or  offline_trainer (mip-offlinetrainer) instead.")
+online_trainer (mip-onlinetrainer) or offline_trainer (mip-offlinetrainer) instead.")

--- a/miprometheus/workers/trainer.py
+++ b/miprometheus/workers/trainer.py
@@ -144,6 +144,11 @@ class Trainer(Worker):
             print('Please pass configuration file(s) as --c parameter')
             exit(-1)
 
+        # Check the presence of the CUDA-compatible devices.
+        if self.flags.use_gpu and (torch.cuda.device_count() == 0):
+            self.logger.error("Cannot use GPU as there are no CUDA-compatible devices present in the system!")
+            exit(-2)
+            
         # Get the list of configurations which need to be loaded.
         configs_to_load = self.recurrent_config_parse(self.flags.config, [])
 

--- a/miprometheus/workers/trainer.py
+++ b/miprometheus/workers/trainer.py
@@ -518,4 +518,4 @@ class Trainer(Worker):
 
 if __name__ == '__main__':
     print("The trainer.py file contains only an abstract base class. Please try to use the \
-online_trainer (mip-onlinetrainer) or offline_trainer (mip-offlinetrainer) instead.")
+online_trainer (mip-onlinetrainer) or  offline_trainer (mip-offlinetrainer) instead.")

--- a/miprometheus/workers/trainer.py
+++ b/miprometheus/workers/trainer.py
@@ -515,3 +515,7 @@ class Trainer(Worker):
 
         # Return the average validation loss.
         return self.validation_stat_agg['loss']
+
+if __name__ == '__main__':
+    print("The trainer.py file contains only an abstract base class. Please try to use the \
+online_trainer (mip-onlinetrainer) or  offline_trainer (mip-offlinetrainer) instead.")

--- a/miprometheus/workers/worker.py
+++ b/miprometheus/workers/worker.py
@@ -159,7 +159,7 @@ class Worker(object):
                                  dest='confirm',
                                  action='store_true',
                                  help='Request user confirmation just after loading the settings, '
-                                      'before starting training  (Default: False)')
+                                      'before starting training. (Default: False)')
 
     def setup_experiment(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -207,14 +207,14 @@ setup(
     # executes the function `main` from this package when invoked:
     entry_points={  # Optional
          'console_scripts': [
-             'mip-offlinetrainer=miprometheus.workers.offline_trainer:main',
-             'mip-onlinetrainer=miprometheus.workers.online_trainer:main',
+             'mip-offline-trainer=miprometheus.workers.offline_trainer:main',
+             'mip-online-trainer=miprometheus.workers.online_trainer:main',
              'mip-tester=miprometheus.workers.tester:main',
-             'mip-gridtrainer-cpu=miprometheus.workers.grid_trainer_cpu:main',
-             'mip-gridtrainer-gpu=miprometheus.workers.grid_trainer_gpu:main',
-             'mip-gridtester-cpu=miprometheus.workers.grid_tester_cpu:main',
-             'mip-gridtester-gpu=miprometheus.workers.grid_tester_gpu:main',
-             'mip-gridanalyzer=miprometheus.workers.grid_analyzer:main',
+             'mip-grid-trainer-cpu=miprometheus.workers.grid_trainer_cpu:main',
+             'mip-grid-trainer-gpu=miprometheus.workers.grid_trainer_gpu:main',
+             'mip-grid-tester-cpu=miprometheus.workers.grid_tester_cpu:main',
+             'mip-grid-tester-gpu=miprometheus.workers.grid_tester_gpu:main',
+             'mip-grid-analyzer=miprometheus.workers.grid_analyzer:main',
          ],
      },
 


### PR DESCRIPTION
This PR solves the following:
- Add cuda-gpupick check to grid_*_gpu workers (fixes #6 )
- Grid workers rely on mip-* scripts (fixes #19 )
- Check presence of cuda-compatible devices in GPU grid workers (fixes #18 )
- Standardization the names of mip scripts (fixes #22 )
- Standardization of the way all worker scripts are reacting for lack of CUDA-compatible devices (fixes #21 )