### PR TITLE
Feat/model loading

### DIFF
--- a/miprometheus/workers/tester.py
+++ b/miprometheus/workers/tester.py
@@ -219,7 +219,7 @@ class Tester(Worker):
             exit(-5)
         except Exception as e:
             self.logger.error(e)
-            # Exit by following the logic: if user wanted to load the model but failer, then continuing the experiment makes no sense.
+            # Exit by following the logic: if user wanted to load the model but failed, then continuing the experiment makes no sense.
             exit(-6)
 
         # Turn on evaluation mode.

--- a/miprometheus/workers/tester.py
+++ b/miprometheus/workers/tester.py
@@ -147,15 +147,15 @@ class Tester(Worker):
             _ = self.params['testing']['problem']['name']
         except:
             print("Error: Couldn't retrieve the problem name from the 'testing' section in the loaded configuration")
-            exit(-1)
+            exit(-5)
 
         # Get model name.
         try:
             _ = self.params['model']['name']
         except:
             print("Error: Couldn't retrieve the model name from the loaded configuration")
-            exit(-1)
-
+            exit(-6)
+            
         # Prepare output paths for logging
         while True:
             # Dirty fix: if log_dir already exists, wait for 1 second and try again
@@ -209,8 +209,18 @@ class Tester(Worker):
         # Create model object.
         self.model = ModelFactory.build(self.params['model'], self.problem.default_values)
 
-        # Load parameters from checkpoint.
-        self.model.load(self.flags.model)
+        # Load the pretrained model from checkpoint.
+        try: 
+            model_name = self.flags.model
+            # Load parameters from checkpoint.
+            self.model.load(model_name)
+        except KeyError:
+            self.logger.error("File {} indicated in the command line (--m) seems not to be a valid model checkpoint".format(model_name))
+            exit(-5)
+        except Exception as e:
+            self.logger.error(e)
+            # Exit by following the logic: if user wanted to load the model but failer, then continuing the experiment makes no sense.
+            exit(-6)
 
         # Turn on evaluation mode.
         self.model.eval()

--- a/miprometheus/workers/trainer.py
+++ b/miprometheus/workers/trainer.py
@@ -461,6 +461,7 @@ class Trainer(Worker):
 
 
         """
+        # Get number of samples - depending whether using sampler or not.
         if self.validations_sampler is not None:
             num_samples = len(self.validations_sampler)
         else:

--- a/miprometheus/workers/trainer.py
+++ b/miprometheus/workers/trainer.py
@@ -278,7 +278,7 @@ class Trainer(Worker):
             exit(-5)
         except Exception as e:
             self.logger.error(e)
-            # Exit by following the logic: if user wanted to load the model but failer, then continuing the experiment makes no sense.
+            # Exit by following the logic: if user wanted to load the model but failed, then continuing the experiment makes no sense.
             exit(-6)
 
         # Move the model to CUDA if applicable.

--- a/miprometheus/workers/trainer.py
+++ b/miprometheus/workers/trainer.py
@@ -255,13 +255,31 @@ class Trainer(Worker):
         # Build the model using the loaded configuration and the default values of the problem.
         self.model = ModelFactory.build(self.params['model'], self.training_problem.default_values)
 
-        # load the indicated pretrained model checkpoint if the argument is valid
-        if self.flags.model != "":
-            if os.path.isfile(self.flags.model):
-                # Load parameters from checkpoint.
-                self.model.load(self.flags.model)
+        # Load the pretrained model from checkpoint.
+        try: 
+            # Check command line arguments, then check load option in config.
+            if self.flags.model != "":
+                model_name = self.flags.model
+                msg = "command line (--m)"
+            elif "load" in self.params['model']:
+                model_name = self.params['model']['load']
+                msg = "model section of the configuration file"
             else:
-                self.logger.error("Couldn't load the checkpoint {} : does not exist on disk.".format(self.flags.model))
+                model_name = ""
+            # Try to load the model.
+            if model_name != "":
+                if os.path.isfile(model_name):
+                    # Load parameters from checkpoint.
+                    self.model.load(model_name)
+                else:
+                    raise Exception("Couldn't load the checkpoint {} indicated in the {}: file does not exist".format(model_name, msg))
+        except KeyError:
+            self.logger.error("File {} indicated in the {} seems not to be a valid model checkpoint".format(model_name, msg))
+            exit(-5)
+        except Exception as e:
+            self.logger.error(e)
+            # Exit by following the logic: if user wanted to load the model but failer, then continuing the experiment makes no sense.
+            exit(-6)
 
         # Move the model to CUDA if applicable.
         if self.app_state.use_CUDA:


### PR DESCRIPTION
 - Adds second option for loading the model to both trainers:
model:
  name: ...
  load: [file name to load]

 - option --m overwrites the config file 'load'

 - Added better exception handling then loading model to tester

Solves #40 