### PR TITLE
[Feature] Linking the documentation to other documentations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -207,6 +207,14 @@ man_pages = [
      1)
 ]
 
+# Example configuration for intersphinx: refer to the Python standard library, and others.
+intersphinx_mapping = {
+    'pytorch': ('https://pytorch.org/docs/stable/', None),
+    'torchvision': ('https://pytorch.org/docs/stable/', None),
+    'python': ('https://docs.python.org/3', None),
+    'yaml': ('https://yaml.readthedocs.io/en/latest/', None),
+    'numpy': ('https://numpy.readthedocs.io/en/latest/', None)
+}
 
 # -- Options for Texinfo output ----------------------------------------------
 
@@ -220,3 +228,7 @@ texinfo_documents = [
 ]
 
 # -- Extension configuration -------------------------------------------------
+
+autodoc_inherit_docstrings = False
+
+autodoc_member_order = 'bysource'

--- a/docs/source/notes/6_updating_doc.rst
+++ b/docs/source/notes/6_updating_doc.rst
@@ -33,29 +33,36 @@ The `.rst` files are written using the reStructuredText plaintext markup syntax.
     =============================
 
     .. automodule:: miprometheus.models
-    .. currentmodule:: miprometheus.models
+
 
     Model  # this is a subtitle
     ---------------------------------
 
-    .. autoclass:: miprometheus.models.model.Model
+    .. autoclass:: Model
         :members:
+        :special-members:
+        :exclude-members: __dict__,__weakref__
 
-    :hidden:`CNN_LSTM_VQA`  # this is a subsubtitle
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    .. automodule:: miprometheus.models.cnn_lstm_vqa
+    :hidden:`CNN + LSTM` # This is a subsubtitle
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    .. automodule:: miprometheus.models.vqa_baselines.cnn_lstm
         :members:
+        :special-members:
+        :exclude-members: __dict__,__weakref__
 
     SequentialModel # this is a subtitle
     ----------------------------------------
-    ..  currentmodule:: miprometheus.models
-    .. autoclass:: miprometheus.models.sequential_model.SequentialModel
+    .. autoclass:: SequentialModel
         :members:
+        :special-members:
+        :exclude-members: __dict__,__weakref__
 
     :hidden:`DWM` # this is a subsubtitle
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     .. automodule:: miprometheus.models.dwm
         :members:
+        :special-members:
+        :exclude-members: __dict__,__weakref__
 
 
 Do not hesitate to frequently refer to the reStructuredText guide_ for more information on the formatting.
@@ -114,19 +121,17 @@ When adding a new module (`.py` file), class or function in the code base, pleas
 - Finally, we have to rebuild the `.html` pages from the `.rst` files. This is done by readthedocs_ when we do a commit to our repository.
 
 
-**NOTE**: We are not using the `setup.py` to build the documentation, but rather pointing readthedocs_ to a requirements.txt file.
+**NOTE**: We are not using the `setup.py` to build the documentation, but rather using mocking_ to ignore the dependencies.
 The reason is as follows:
 
-    - The installation of the framework (through `python setup.py install`) should require the latest version of torchvision (currently `0.2.1`) as we get an error: AttributeError: module 'torchvision.transforms' has no attribute 'Resize' with `torchvision<=0.2.0`. It's also best if we do not have that version constraint at all.
-    - The documentation build requires `torchvision<=0.2.0` as `0.2.1` seems to cause the error: `AttributeError: module 'PIL.Image' has no attribute 'LANCZOS'`. We believe that the docker environment used for building the docs is causing this.
+    - The installation of the framework (through `python setup.py install`) can be resource intensive and the docker backend of readthedocs is constrained in terms of memory.
+    - The documentation build should be pretty fast. Hence, avoiding dealing with dependencies is better.
 
-
-So the current solution is to not use `python setup.py install` for the doc build (which is not needed at every re-build, as the docker environment is cached), but to instead point to `docs/requirements.txt` which contains `torchvision==0.2.0`.
-This allows to separate these 2 build processes.
 
 Please refer to the `readthedocs.yml` file to see the configuration for the documentation build.
 
 .. _readthedocs: https://readthedocs.org/projects/mi-prometheus/
+.. _mocking: https://docs.python.org/3/library/unittest.mock.html
 
 Some quotes about Code Documentation
 -------------------------------------------

--- a/miprometheus/models/model.py
+++ b/miprometheus/models/model.py
@@ -35,7 +35,7 @@ class Model(Module):
     """
     Class representing base class for all Models.
 
-    Inherits from ``torch.nn.Module`` as all subclasses will represent a trainable model.
+    Inherits from :py:class:`torch.nn.Module` as all subclasses will represent a trainable model.
 
     Hence, all subclasses should override the ``forward`` function.
 

--- a/miprometheus/problems/problem.py
+++ b/miprometheus/problems/problem.py
@@ -32,8 +32,8 @@ class Problem(Dataset):
     """
     Class representing base class for all Problems.
 
-    Inherits from torch.utils.data.Dataset as all subclasses will represent a problem with an associated dataset,\
-    and the `worker` will use ``torch.utils.data.dataloader.DataLoader`` to generate batches.
+    Inherits from :py:class:`torch.utils.data.Dataset` as all subclasses will represent a problem with an associated dataset,\
+    and the `worker` will use :py:class:`torch.utils.data.DataLoader` to generate batches.
 
     Implements features & attributes used by all subclasses.
 

--- a/miprometheus/problems/problem_factory.py
+++ b/miprometheus/problems/problem_factory.py
@@ -40,7 +40,7 @@ class ProblemFactory(object):
         provided in the list of parameters.
 
         :param params: Parameters used to instantiate the Problem class.
-        :type params: ``utils.param_interface.ParamInterface``
+        :type params: :py:class:`miprometheus.utils.ParamInterface`
 
         ..note::
 


### PR DESCRIPTION
It is possible to link the documentation to refer to the Python standard library, or others librairies' documentation. 
For the builtins of Python, it seems that it works not too bad out-of-the-box. For instance, if we specify the type of an argument in a function's docstring, e.g. `:type name: str`, a hyperlink refering to [str](https://docs.python.org/3/library/stdtypes.html#str)'s doc page is created when the documentation is built.

It is possible also to link to PyTorch documentation, but it requires a bit more work. For instance, to link to the doc page of [`Dataset`](https://pytorch.org/docs/stable/data.html#torch.utils.data.Dataset), we have to indicate the following in the docstring: 

> :py:class:`torch.utils.data.Dataset`

`:py:class` is thus the directive to use to tell Sphinx that we want to link to this class's doc page. That can work with numpy, torchvision etc.

There are so many ways in which we could enhance the documentation, and I feel like we are barely scratching the surface...