### PR TITLE
Use LGTM and flake8 to find some missing imports

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,3 +5,11 @@ extraction:
     index:
       exclude:
         - .git
+    after_prepare:
+      - python3 -m pip install --upgrade --user flake8
+    before_index:
+      - python3 -m flake8 --version  # flake8 3.6.0 on CPython 3.6.5 on Linux
+      # stop the build if there are Python syntax errors or undefined names
+      - python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+      # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+      - python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
* Should __ScratchPad()__ instead be [__ScratchPadCommandLines()__](https://github.com/IBM/mi-prometheus/blob/develop/miprometheus/problems/seq_to_seq/algorithmic/recall/scratch_pad_cl.py#L27)?
* __save_movie()__ can be found [in upstream](https://github.com/google/cog/blob/master/cognitive/stim_generator.py#L790).

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/mi-prometheus on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./miprometheus/problems/seq_to_seq/algorithmic/recall/scratch_pad_cl.py:176:18: F821 undefined name 'ScratchPad'
    scratchpad = ScratchPad(params)
                 ^
./miprometheus/problems/seq_to_seq/vqa/cog/cog_utils/stim_generator.py:758:5: F821 undefined name 'save_movie'
    save_movie(movie, save_name, t_total)
    ^
./miprometheus/problems/seq_to_seq/vqa/cog/cog_utils/stim_generator.py:797:5: F821 undefined name 'save_movie'
    save_movie(movie, save_name, t_total)
    ^
3     F821 undefined name 'ScratchPad'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree