### PR TITLE
Mac Sequential Visualization

### DIFF
--- a/miprometheus/models/mac_sequential/mac_unit.py
+++ b/miprometheus/models/mac_sequential/mac_unit.py
@@ -153,6 +153,9 @@ class MACUnit(Module):
 
             memories = [memory]
 
+        #empty state history
+        self.cell_state_history = []
+
 
         # main loop of recurrence over the MACCell
         for i in range(self.max_step):
@@ -195,4 +198,4 @@ class MACUnit(Module):
                 self.cell_state_history.append(
                     (self.read.rvi.cpu().detach(), self.control.cvi.cpu().detach()))
 
-        return memory, controls, memories
+        return memory, controls, memories, self.cell_state_history

--- a/miprometheus/models/mac_sequential/model.py
+++ b/miprometheus/models/mac_sequential/model.py
@@ -627,7 +627,7 @@ class MACNetworkSequential(Model):
             # Plot figure and list of frames.
             self.plotWindow.update(fig, frames)
 
-        return self.plotWindow.is_closed
+        #return self.plotWindow.is_closed
 
 
     def get_dropout_mask(self, x, dropout):

--- a/miprometheus/models/mac_sequential/model.py
+++ b/miprometheus/models/mac_sequential/model.py
@@ -53,6 +53,7 @@ import os
 import nltk
 import torch
 import numpy as np
+import matplotlib.pylab
 from PIL import Image
 from torchvision import transforms
 from miprometheus.models.model import Model
@@ -159,6 +160,9 @@ class MACNetworkSequential(Model):
         # Input Image size
         self.image_size = [112, 112]
 
+        # history states
+        self.cell_states = []
+
         # Visual memory shape. height x width.
         self.vstm_shape = np.array(self.image_size)
         for channel in self.visual_processing_channels:
@@ -245,6 +249,8 @@ class MACNetworkSequential(Model):
         controls = [control]
         memories = [memory]
 
+        self.cell_states=[]
+
         # Loop over all elements along the SEQUENCE dimension.
         for i in range(images.size(0)):
 
@@ -266,9 +272,12 @@ class MACNetworkSequential(Model):
             img, kb_proj, lstm_out, h = self.input_unit(questions, questions_length, x)
 
             # recurrent MAC cells
-            memory, controls, memories = self.mac_unit(lstm_out, h, img, kb_proj, controls, memories, self.control_pass, self.memory_pass, control, memory)
+            memory, controls, memories , state_history = self.mac_unit(lstm_out, h, img, kb_proj, controls, memories, self.control_pass, self.memory_pass, control, memory)
 
-           # output unit
+            #save state history
+            self.cell_states.append(state_history)
+
+            # output unit
             logits_answer[:,i,:] = self.output_unit_answer(memory, h)
             logits_pointing[:,i,:] = self.output_unit_pointing(memory, h)
 
@@ -413,19 +422,14 @@ class MACNetworkSequential(Model):
         Visualize the attention weights (``ControlUnit`` & ``ReadUnit``) on the \
         question & feature maps. Dynamic visualization throughout the reasoning \
         steps is possible.
-
         :param data_dict: DataDict({'images','questions', 'questions_length', 'questions_string', 'questions_type', \
         'targets', 'targets_string', 'index','imgfiles', 'prediction_string'})
         :type data_dict: utils.DataDict
-
         :param logits: Prediction of the model.
         :type logits: torch.tensor
-
         :param sample: Index of sample in batch (Default: 0)
         :type sample: int
-
         :return: True when the user closes the window, False if we do not need to visualize.
-
         """
 
         # check whether the visualization is required
@@ -439,98 +443,213 @@ class MACNetworkSequential(Model):
 
         # unpack data_dict
         s_questions = data_dict['questions_string']
-        question_type = data_dict['questions_type']
-        answer_string = data_dict['targets_string']
-        imgfiles = data_dict['imgfiles']
-        prediction_string = data_dict['predictions_string']
-        clevr_dir = data_dict['clevr_dir']
+        s_answers = data_dict['answers_string']
+        vocab = data_dict['vocab']
+        images = data_dict['images']
+        tasks = data_dict['tasks']
+        mask_pointing = data_dict['masks_pnt']
 
-        # needed for nltk.word.tokenize
-        nltk.download('punkt')
-        # tokenize question string using same processing as in the problem
-        # class
-        words = nltk.word_tokenize(s_questions[sample])
+        #### CLASSIFICATION VISU ######
 
-        # Create figure template.
-        fig = self.generate_figure_layout()
-        # Get axes that artists will draw on.
-        (ax_image, ax_attention_image, ax_attention_question, ax_step) = fig.axes
+        if mask_pointing.sum()==0:
 
-        # get the image
-        set = imgfiles[sample].split('_')[1]
-        image = os.path.join(clevr_dir, 'images', set, imgfiles[sample])
-        image = Image.open(image).convert('RGB')
-        image = self.transform(image)
-        image = image.permute(1, 2, 0)  # [300, 300, 3]
+            # get samples
+            tasks = tasks[sample]
 
-        # get most probable answer -> prediction of the network
-        proba_answers = torch.nn.functional.softmax(logits, -1)
-        proba_answer = proba_answers[sample].detach().cpu()
-        proba_answer = proba_answer.max().numpy()
+            # get prediction
+            values, indices = torch.max(logits[0], 2)
+            prediction = indices[sample]
 
-        # image & attention sizes
-        width = image.size(0)
-        height = image.size(1)
+            # needed for nltk.word.tokenize
+            nltk.download('punkt')
 
-        frames = []
-        for step, (attention_mask, attention_question) in zip(
-                range(self.max_step), self.mac_unit.cell_state_history):
-            # preprocess attention image, reshape
-            attention_size = int(np.sqrt(attention_mask.size(-1)))
-            # attention mask has size [batch_size x 1 x(H*W)]
-            attention_mask = attention_mask.view(-1, 1, attention_size, attention_size)
+            # tokenize question string using same processing as in the problem
+            words = s_questions[sample][0]
+            words = nltk.word_tokenize(words)
 
-            # upsample attention mask
-            m = torch.nn.Upsample(
-                size=[width, height], mode='bilinear', align_corners=True)
-            up_sample_attention_mask = m(attention_mask)
-            attention_mask = up_sample_attention_mask[sample, 0]
+            # Create figure template.
+            fig = self.generate_figure_layout()
 
-            # preprocess question, pick one sample number
-            attention_question = attention_question[sample]
+            # Get axes that artists will draw on.
+            (ax_image, ax_attention_image, ax_attention_question, ax_step) = fig.axes
 
-            # Create "Artists" drawing data on "ImageAxes".
-            num_artists = len(fig.axes) + 1
-            artists = [None] * num_artists
+            #initiate list of artists frames
+            frames = []
 
-            # set title labels
-            ax_image.set_title(
-                'CLEVR image: {}'.format(imgfiles[sample]))
-            ax_attention_question.set_xticklabels(
-                ['h'] + words, rotation='vertical', fontsize=10)
-            ax_step.axis('off')
+            #loop over the seqence of frames
+            for i in range(images.size(1)):
 
-            # set axis attention labels
-            ax_attention_image.set_title(
-                'Predicted Answer: ' + prediction_string[sample] +
-                ' [ proba: ' + str.format("{0:.3f}", proba_answer) + ']  ' +
-                'Ground Truth: ' + answer_string[sample])
+                #get image sample
+                image = images[sample][i]
+                image = image.permute(1, 2, 0)
 
-            # Tell artists what to do:
-            artists[0] = ax_image.imshow(
-                image, interpolation='nearest', aspect='auto')
-            artists[1] = ax_attention_image.imshow(
-                image, interpolation='nearest', aspect='auto')
-            artists[2] = ax_attention_image.imshow(
-                attention_mask,
-                interpolation='nearest',
-                aspect='auto',
-                alpha=0.5,
-                cmap='Reds')
-            artists[3] = ax_attention_question.imshow(
-                attention_question.transpose(1, 0),
-                interpolation='nearest', aspect='auto', cmap='Reds')
-            artists[4] = ax_step.text(
-                0, 0.5, 'Reasoning step index: ' + str(step) + ' | Question type: ' + question_type[sample],
-                fontsize=15)
+                #get images dimensions
+                width = images.size(3)
+                height = images.size(4)
 
-            # Add "frame".
-            frames.append(artists)
+                #get answer and prediction strings
+                pred = vocab[prediction[i]]
+                ans = s_answers[sample][i]
 
-        # Plot figure and list of frames.
-        self.plotWindow.update(fig, frames)
 
-        return self.plotWindow.is_closed
+                #loop over the k reasoning steps
+                for step, (attention_mask, attention_question) in zip(
+                        range(self.max_step), self.cell_states[i]):
+
+                    # preprocess attention image, reshape
+                    attention_size = int(np.sqrt(attention_mask.size(-1)))
+
+                    # attention mask has size [batch_size x 1 x(H*W)]
+                    attention_mask = attention_mask.view(-1, 1, attention_size, attention_size)
+
+                    # upsample attention mask
+                    m = torch.nn.Upsample(
+                        size=[width, height], mode='bilinear', align_corners=True)
+                    up_sample_attention_mask = m(attention_mask)
+                    attention_mask = up_sample_attention_mask[sample, 0]
+
+                    # preprocess question, pick one sample number
+                    attention_question = attention_question[sample]
+
+                    # Create "Artists" drawing data on "ImageAxes".
+                    num_artists = len(fig.axes) + 1
+                    artists = [None] * num_artists
+
+                    # set title labels
+                    ax_image.set_title(
+                        'COG image:')
+                    ax_attention_question.set_xticklabels(
+                        ['h'] + words, rotation='vertical', fontsize=10)
+                    ax_step.axis('off')
+
+                    # Tell artists what to do:
+                    artists[0] = ax_image.imshow(
+                        image, interpolation='nearest', aspect='auto')
+                    artists[1] = ax_attention_image.imshow(
+                        image, interpolation='nearest', aspect='auto')
+                    artists[2] = ax_attention_image.imshow(
+                        attention_mask,
+                        interpolation='nearest',
+                        aspect='auto',
+                        alpha=0.5,
+                        cmap='Reds')
+                    artists[3] = ax_attention_question.imshow(
+                        attention_question.transpose(1, 0),
+                        interpolation='nearest', aspect='auto', cmap='Reds')
+                    artists[4] = ax_step.text(
+                        0, 0.5, 'Reasoning step index: ' + str(
+                            step) + ' | Question type: ' + tasks + '         ' + 'Predicted Answer: ' + pred + '  ' +
+                                'Ground Truth: ' + ans,
+                        fontsize=15)
+
+                    # Add "frames" to artist list
+                    frames.append(artists)
+
+            # Plot figure and list of frames.
+            self.plotWindow.update(fig, frames)
+
+        else:
+
+            ###### POINTING VISUALIZATION #########
+
+            # get samples
+            tasks = tasks[sample]
+
+            #get distribution
+            softmax_pointing = nn.Softmax(dim=1)
+            preds_pointing = softmax_pointing(logits[1])
+
+
+            # get images dimensions
+            width = images.size(3)
+            height = images.size(4)
+
+            # needed for nltk.word.tokenize
+            nltk.download('punkt')
+
+            # tokenize question string using same processing as in the problem
+            words = s_questions[sample][0]
+            words = nltk.word_tokenize(words)
+
+            # Create figure template.
+            fig = self.generate_figure_layout()
+
+            # Get axes that artists will draw on.
+            (ax_image, ax_attention_image, ax_attention_question, ax_step) = fig.axes
+
+            # initiate list of artists frames
+            frames = []
+
+            # loop over the seqence of frames
+            for i in range(images.size(1)):
+
+                # get image sample
+                image = images[sample][i]
+                image = image.permute(1, 2, 0)
+
+
+                # loop over the k reasoning steps
+                for step, (attention_mask, attention_question) in zip(
+                        range(self.max_step), self.cell_states[i]):
+                    # preprocess attention image, reshape
+                    attention_size = int(np.sqrt(attention_mask.size(-1)))
+
+                    # attention mask has size [batch_size x 1 x(H*W)]
+                    attention_mask = attention_mask.view(-1, 1, attention_size, attention_size)
+
+                    # upsample attention mask
+                    m = torch.nn.Upsample(
+                        size=[width, height], mode='bilinear', align_corners=True)
+                    up_sample_attention_mask = m(attention_mask)
+                    attention_mask = up_sample_attention_mask[sample, 0]
+
+                    # upsample attention mask
+                    preds_pointing = preds_pointing.view(48,4,7, -1)
+                    mm =torch.nn.Upsample(size=[width, height] , mode= 'bilinear')
+                    up_sample_preds_pointing = mm(preds_pointing)
+                    up_sample_preds_pointing = up_sample_preds_pointing[sample][i]
+
+
+                    # preprocess question, pick one sample number
+                    attention_question = attention_question[sample]
+
+                    # Create "Artists" drawing data on "ImageAxes".
+                    num_artists = len(fig.axes) + 1
+                    artists = [None] * num_artists
+
+                    # set title labels
+                    ax_image.set_title(
+                        'COG image:')
+                    ax_attention_question.set_xticklabels(
+                        ['h'] + words, rotation='vertical', fontsize=10)
+                    ax_step.axis('off')
+                    ax_attention_image.set_title(
+                        'Pointing Distribution')
+
+                    # Tell artists what to do:
+                    artists[0] = ax_image.imshow(
+                        image, interpolation='nearest', aspect='auto')
+                    artists[1] = ax_attention_image.imshow(
+                        image, interpolation='nearest', aspect='auto')
+                    artists[2] = ax_attention_image.imshow(
+                        up_sample_preds_pointing.detach().numpy(),
+                        interpolation='nearest',
+                        aspect='auto',
+                        alpha=0.5,
+                        cmap='Blues')
+                    artists[3] = ax_attention_question.imshow(
+                        attention_question.transpose(1, 0),
+                        interpolation='nearest', aspect='auto', cmap='Reds')
+                    artists[4] = ax_step.text(
+                        0, 0.5, 'Reasoning step index: ' + str(
+                            step) + ' | Question type: ' + tasks,
+                        fontsize=15)
+
+                    # Add "frames" to artist list
+                    frames.append(artists)
+
+            # Plot figure and list of frames.
+            self.plotWindow.update(fig, frames)
 
 
     def get_dropout_mask(self, x, dropout):

--- a/miprometheus/models/mac_sequential/model.py
+++ b/miprometheus/models/mac_sequential/model.py
@@ -52,6 +52,7 @@ __author__ = "Vincent Marois , Vincent Albouy"
 import nltk
 import torch
 import numpy as np
+import matplotlib.pylab
 from torchvision import transforms
 from miprometheus.models.model import Model
 import numpy as numpy

--- a/miprometheus/models/mac_sequential/model.py
+++ b/miprometheus/models/mac_sequential/model.py
@@ -49,12 +49,10 @@ model.py:
 """
 __author__ = "Vincent Marois , Vincent Albouy"
 
-import os
 import nltk
 import torch
 import numpy as np
 import matplotlib.pylab
-from PIL import Image
 from torchvision import transforms
 from miprometheus.models.model import Model
 import numpy as numpy
@@ -483,7 +481,7 @@ class MACNetworkSequential(Model):
             for i in range(images.size(1)):
 
                 #get image sample
-                image = images[sample][i]
+                image = images[sample][i]/255
 
                 # needs [W x H x Channels] for Matplolib.imshow
                 image = image.permute(1, 2, 0)
@@ -574,22 +572,11 @@ class MACNetworkSequential(Model):
                 image = images[sample][i]
 
                 #needs [W x H x Channels] for Matplolib.imshow
-                image = image.permute(1, 2, 0)
+                image = image.permute(1, 2, 0)/255
 
                 # loop over the k reasoning steps
                 for step, (attention_mask, attention_question) in zip(
                         range(self.max_step), self.cell_states[i]):
-                    # preprocess attention image, reshape
-                    attention_size = int(np.sqrt(attention_mask.size(-1)))
-
-                    # attention mask has size [batch_size x 1 x(H*W)]
-                    attention_mask = attention_mask.view(-1, 1, attention_size, attention_size)
-
-                    # upsample attention mask
-                    m = torch.nn.Upsample(
-                        size=[width, height], mode='bilinear', align_corners=True)
-                    up_sample_attention_mask = m(attention_mask)
-                    attention_mask = up_sample_attention_mask[sample, 0]
 
                     # upsample attention mask
                     original_grid_size=7
@@ -638,6 +625,8 @@ class MACNetworkSequential(Model):
 
             # Plot figure and list of frames.
             self.plotWindow.update(fig, frames)
+
+        return self.plotWindow.is_closed
 
 
     def get_dropout_mask(self, x, dropout):

--- a/miprometheus/models/mac_sequential/model.py
+++ b/miprometheus/models/mac_sequential/model.py
@@ -52,7 +52,6 @@ __author__ = "Vincent Marois , Vincent Albouy"
 import nltk
 import torch
 import numpy as np
-import matplotlib.pylab
 from torchvision import transforms
 from miprometheus.models.model import Model
 import numpy as numpy

--- a/miprometheus/models/mac_sequential/model.py
+++ b/miprometheus/models/mac_sequential/model.py
@@ -53,6 +53,7 @@ import nltk
 import torch
 import numpy as np
 import matplotlib.pylab
+import matplotlib.animation
 from torchvision import transforms
 from miprometheus.models.model import Model
 import numpy as numpy

--- a/miprometheus/problems/seq_to_seq/video_text_to_class/cog/cog.py
+++ b/miprometheus/problems/seq_to_seq/video_text_to_class/cog/cog.py
@@ -774,6 +774,8 @@ class COG(VideoTextToClassProblem):
 		stat_col['acc'] = acc_total
 		stat_col['acc_answer'] = acc_answer
 		stat_col['acc_pointing'] = acc_pointing
+		if self.set == 'test' :
+			self.get_acc_per_family(data_dict, logits)
 		#self.get_acc_per_family(data_dict, logits)
 		#stat_col['seq_len'] = self.sequence_length
 		#stat_col['max_mem'] = self.memory_length

--- a/miprometheus/problems/seq_to_seq/video_text_to_class/cog/cog.py
+++ b/miprometheus/problems/seq_to_seq/video_text_to_class/cog/cog.py
@@ -41,7 +41,6 @@ import os
 import tarfile
 import string
 import numpy as np
-import matplotlib.pyplot as plt
 from miprometheus.problems.seq_to_seq.video_text_to_class.video_text_to_class_problem import VideoTextToClassProblem
 from miprometheus.problems.seq_to_seq.video_text_to_class.cog.cog_utils import json_to_img as jti
 

--- a/miprometheus/problems/seq_to_seq/video_text_to_class/cog/cog.py
+++ b/miprometheus/problems/seq_to_seq/video_text_to_class/cog/cog.py
@@ -41,7 +41,7 @@ import os
 import tarfile
 import string
 import numpy as np
-
+import matplotlib.pyplot as plt
 from miprometheus.problems.seq_to_seq.video_text_to_class.video_text_to_class_problem import VideoTextToClassProblem
 from miprometheus.problems.seq_to_seq.video_text_to_class.cog.cog_utils import json_to_img as jti
 
@@ -243,7 +243,7 @@ class COG(VideoTextToClassProblem):
 								 'SimpleExistGo','SimpleExistShapeGo']
 
 
-		self.tuple_list = [[0, 0] for _ in range(len(self.categories))]
+		self.tuple_list = [[0,0,0] for _ in range(len(self.categories))]
 
 		self.categories_stats = dict(zip(self.categories, self.tuple_list))
 
@@ -502,19 +502,15 @@ class COG(VideoTextToClassProblem):
 			# pointing
 			self.categories_stats[tasks[i]][0] += float(mask_pointing_non_flatten[i].sum().item())
 
+			#put task accuracy in third position of the dictionary
+			if self.categories_stats[tasks[i]][0]==0:
+				self.categories_stats[tasks[i]][2] = 0.0
 
-        #display accuracies per task
-		for task in self.categories:
-
-			if self.categories_stats[task][1] == 0.0:
-				acc = 0.0
 			else:
-				total = self.categories_stats[task][0]
-				correct = self.categories_stats[task][1]
-				acc = correct/total
+				self.categories_stats[tasks[i]][2] = self.categories_stats[tasks[i]][1]/self.categories_stats[tasks[i]][0]
 
-			print('accuracy for task',task, '=' , acc )
 
+		return self.categories_stats
 
 
 
@@ -568,6 +564,7 @@ class COG(VideoTextToClassProblem):
 
 		data_dict['tasks']	= self.dataset[index]['family']
 		data_dict['questions'] = [self.dataset[index]['question']]
+
 		data_dict['questions_string'] = [self.dataset[index]['question']]
 		data_dict['questions'] = torch.LongTensor([self.input_vocab.index(word) for word in data_dict['questions'][0].split()])
 		if(data_dict['questions'].size(0) <= self.nwords):
@@ -751,10 +748,10 @@ class COG(VideoTextToClassProblem):
 		stat_col.add_statistic('acc', '{:12.10f}')
 		stat_col.add_statistic('acc_answer', '{:12.10f}')
 		stat_col.add_statistic('acc_pointing', '{:12.10f}')
-		#stat_col.add_statistic('seq_len', '{:06d}')
-		#stat_col.add_statistic('max_mem', '{:06d}')
-		#stat_col.add_statistic('max_distractors', '{:06d}')
-		#stat_col.add_statistic('task', '{}')
+		stat_col.add_statistic('acc_families', '{}')
+
+
+
 
 	def collect_statistics(self, stat_col, data_dict, logits):
 		"""
@@ -769,18 +766,15 @@ class COG(VideoTextToClassProblem):
 		stat_col['loss_answer'] = self.loss_answer.cpu().item()
 		stat_col['loss_pointing'] = self.loss_pointing.cpu().item()
 
-		# Accuracy.
+		# Accuracies.
 		acc_total, acc_answer, acc_pointing = self.calculate_accuracy(data_dict, logits)
 		stat_col['acc'] = acc_total
 		stat_col['acc_answer'] = acc_answer
 		stat_col['acc_pointing'] = acc_pointing
-		if self.set == 'test' :
-			self.get_acc_per_family(data_dict, logits)
-		#self.get_acc_per_family(data_dict, logits)
-		#stat_col['seq_len'] = self.sequence_length
-		#stat_col['max_mem'] = self.memory_length
-		#stat_col['max_distractors'] = self.max_distractors
-		#stat_col['task'] = data_dict['tasks']			
+
+		#saving the entire dictionnary families[ correct, total, accuracy]  as a statistic 
+		stat_col['acc_families'] = self.get_acc_per_family(data_dict, logits)
+
 
 
 

--- a/miprometheus/problems/seq_to_seq/video_text_to_class/cog/cog.py
+++ b/miprometheus/problems/seq_to_seq/video_text_to_class/cog/cog.py
@@ -568,6 +568,7 @@ class COG(VideoTextToClassProblem):
 
 		data_dict['tasks']	= self.dataset[index]['family']
 		data_dict['questions'] = [self.dataset[index]['question']]
+		data_dict['questions_string'] = [self.dataset[index]['question']]
 		data_dict['questions'] = torch.LongTensor([self.input_vocab.index(word) for word in data_dict['questions'][0].split()])
 		if(data_dict['questions'].size(0) <= self.nwords):
 			prev_size = data_dict['questions'].size(0)
@@ -576,6 +577,7 @@ class COG(VideoTextToClassProblem):
 
 		# Set targets - depending on the answers.
 		answers = self.dataset[index]['answers']
+		data_dict['answers_string'] = self.dataset[index]['answers']
 		if data_dict['tasks'] in self.classification_tasks:
 			data_dict['targets_answer'] = self.output_class_to_int(answers)
 		else :
@@ -607,6 +609,11 @@ class COG(VideoTextToClassProblem):
 		# Masks.
 		data_dict['masks_pnt']	= torch.stack([sample['masks_pnt'] for sample in batch]).type(self.app_state.ByteTensor)
 		data_dict['masks_word']	= torch.stack([sample['masks_word'] for sample in batch]).type(self.app_state.ByteTensor)
+		data_dict['vocab'] = self.output_vocab
+
+        #strings question and answer
+		data_dict['questions_string'] = [question['questions_string'] for question in batch]
+		data_dict['answers_string'] = [answer['answers_string'] for answer in batch]
 
 		return data_dict
 


### PR DESCRIPTION
In this pull request I plug a Visualization:

- Fisrt it tests if it is a Classification task or Pointing task
- For classification task it displays: Question,  Attention on question,  Image , Attention on Image , Predicted Answer, Ground Truth 
- For pointing task it displays: Question, Attention on question, Image = Ground Truth, Predicted Pointing distribution 

cog.py has some modifications, just to get access to strings questions and string answers

Simply  run: mip-tester --c configs/cog/cog_mac.yaml --visualize 1  (with a trained model) 