### PR TITLE
Undefined name: seq_length --> seq_lengths

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,7 +1,0 @@
-extraction:
-  python:
-    python_setup:
-      version: 3
-    index:
-      exclude:
-        - .git

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,11 +5,3 @@ extraction:
     index:
       exclude:
         - .git
-    after_prepare:
-      - python3 -m pip install --upgrade --user flake8
-    before_index:
-      - python3 -m flake8 --version  # flake8 3.6.0 on CPython 3.6.5 on Linux
-      # stop the build if there are Python syntax errors or undefined names
-      - python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-      # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-      - python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,16 @@ branches:
     - develop
 
 install:
-  - pip3 install -r requirements.txt
+  - pip3 install flake8 -r requirements.txt
+
+before_script:
+  # Test plake8 compatibility.
+  - python3 -m flake8 --version  # flake8 3.6.0 on CPython 3.6.5 on Linux
+  # stop the build if there are Python syntax errors or undefined names
+  - python3 -m flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
-  # Test plake8 compatibility.
-  #- python3 -m flake8 --version  # flake8 3.6.0 on CPython 3.6.5 on Linux
-  # stop the build if there are Python syntax errors or undefined names
-  #- python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  #- python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   # Try to build documentation.
   - ./docs/build_docs.sh

--- a/miprometheus/problems/seq_to_seq/algorithmic/recall/scratch_pad_cl.py
+++ b/miprometheus/problems/seq_to_seq/algorithmic/recall/scratch_pad_cl.py
@@ -155,7 +155,7 @@ class ScratchPadCommandLines(AlgorithmicSeqToSeqProblem):
         data_dict['sequences'] = torch.from_numpy(inputs).type(self.app_state.dtype)
         data_dict['targets'] = torch.from_numpy(targets).type(self.app_state.dtype)
         data_dict['masks'] = ptmasks
-        data_dict['sequences_length'] = torch.ones([batch_size,1]).type(torch.IntTensor) * seq_length
+        data_dict['sequences_length'] = torch.ones([batch_size,1]).type(torch.IntTensor) * seq_lengths
         data_dict['num_subsequences'] = torch.ones([batch_size, 1]).type(torch.CharTensor) * num_sub_seq
         return data_dict
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,17 +3,12 @@ Babel==2.6.0
 certifi==2018.11.29
 chardet==3.0.4
 docutils==0.14
-entrypoints==0.3
-flake8==3.7.5
 idna==2.8
 imagesize==1.1.0
 Jinja2==2.10.1
 MarkupSafe==1.1.0
-mccabe==0.6.1
 packaging==19.0
 Pillow==5.4.1
-pycodestyle==2.5.0
-pyflakes==2.1.0
 Pygments==2.3.1
 pyparsing==2.3.1
 pytz==2018.9


### PR DESCRIPTION
Blocked by #146 bacause LGTM will continue running the old analytics until AFTER the __.lgtm.yml__ file is deleted from the repo.

__seq_length__ (singular) is an _undefined name_ in this context so this PR proposes to use __seq_lengths__ (plural) instead.

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/mi-prometheus on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./miprometheus/problems/seq_to_seq/algorithmic/recall/scratch_pad_cl.py:158:92: F821 undefined name 'seq_length'
        data_dict['sequences_length'] = torch.ones([batch_size,1]).type(torch.IntTensor) * seq_length
                                                                                           ^
1     F821 undefined name 'seq_length'
1
```
[LGTM.com does not want flake8 to be run on their infrastructure](https://discuss.lgtm.com/t/can-i-get-lgtm-to-run-flake8-tests/1445) so remove __.lgtm.yml__ and move the flake8 tests back to Travis CI.

Remove flake8 packages from __requirements.txt__ because they are used only at test time and are not runtime requirements for mi-prometheus.